### PR TITLE
Fix bug caused by older commit

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -135,7 +135,7 @@ class Client extends EventEmitter {
                     	this.guilds.set(message.d.id, new Guild(this, message.d));
                     	message.d.channels.forEach(channel => this.channels.set(channel.id, new Channel(this, channel, message.d.id)))
                     	message.d.members.map(member => member.user).forEach(user => {
-                    	   if (!this.users.has(user.id)) this.users.set(user.id, new User(this, user));
+                    	   if (!this.users.has(user.id)) this.users.set(user.id, new User(user));
                     	})
                     	this.guild = new Guild(this, message.d)
                     break;

--- a/lib/structs/Guild.js
+++ b/lib/structs/Guild.js
@@ -23,7 +23,7 @@ class Guild {
         this.roles = new Map(data.roles.map(role => [role.id, new Role(client, role)]));
         this.emojis = data.emojis;
         this.channels = new Map(data.channels.map(channel => [channel.id, new Channel(client, channel)]));
-        this.members = new Map(data.members.map(member => [member.user.id, new Member(client, member, this.id)]));
+        this.members = new Map(data.members.map(member => [member.user.id, new Member(member, this.id)]));
         this.owner = this.members.get(data.owner_id).user;
     }
 

--- a/lib/structs/User.js
+++ b/lib/structs/User.js
@@ -8,7 +8,7 @@
 * @prop {Boolean} bot Determines whether the user is a bot or not (true or false)
 */
 class User {
-    constructor(client, data) {
+    constructor(data) {
         this.id = data.id;
         this.username = this.name = data.username;
         this.discriminator = this.discrim = data.discriminator;


### PR DESCRIPTION
Changing User constructor parameters caused a breaking change
which needed a lot of changing. So, this commit rolls back the
last commit. Instead, to keep it simple, in a single line
in Client.js that is calling User constructor, client is removed
from its arguments keeping arguments list as expected from
the constructor.

Apparently, in Guild structure, the Member constructor was
also being wrongly called with client as an extra parameter.
This commit fixes it.